### PR TITLE
Updated with 5 basic charting macros.

### DIFF
--- a/Performance Analytics Library/macro/Chart_Autoregression.sas
+++ b/Performance Analytics Library/macro/Chart_Autoregression.sas
@@ -1,0 +1,122 @@
+/*---------------------------------------------------------------
+* NAME: Chart_AutoRegression.sas
+*
+* PURPOSE: Creates a series of auto-regression charts for analysis using a returns data set.
+*		   This macro is in tandem with chart.ACFplus from the R Performance Analytics Library.
+*		   Therefore, the default options are set to plot only ACF and PACF charts, with user discretion that
+*		   there are many more plots for analysis available which have been included in this macro.
+*
+* MACRO OPTIONS:
+* returns - required.  Data Set containing returns.
+* asset- required.  Specifies the variable or asset to be plotted.
+* lag- required.  Specifies the amount of lags to plot in each chart.
+* title- required.  Title for Charts. [Default= AutoRegression Analysis for &asset]
+* all- option.  Option to plot all charts available via Proc Timeseries for analysis. [Default= FALSE]
+* ACF- option. Option to plot an ACF chart for the specified lag. [Default= TRUE]
+* PACF- option.  Option to plot a PACF chart for the specified lag. [Default= TRUE]
+* WN- option.  Option to plot White Noise charts for the specified lag. [Default= FALSE]
+* IACF- option.  Option to plot Inverse ACF charts for the specified lag. [Default= FALSE]
+* Residual- option.  Option to plot Residual charts for the specified lag. [Default= FALSE]
+* SeasonalAdjusted- option.  Option to plot a Seasonal adjusted chart for the specified lag. [Default= FALSE]
+* SeasonalComponent- option.  Option to plot a Seasonal component chart for the specified lag. [Default= FALSE]
+* SeasonalCycle- option.  Option to plot a Seasonal cycle chart for the specified lag. [Default= FALSE]
+* TrendComponent- option.  Option to plot a trend component chart for the specified lag. [Default= FALSE]
+* TrendCycleComponent- option.  Option to plot a trend cycle component chart for the specified lag. [Default= FALSE]
+* TrendCycleSeasonal- option.  Option to plot a Seasonally adjusted trend cycle chart for the specified lag. [Default= FALSE]
+* dateColumn- specifies the date column for returns in the data set. [Default= Date]
+*
+* MODIFIED:
+* 1/25/2016 – CJ - Initial Creation
+*
+* Copyright (c) 2016 by The Financial Risk Group, Cary, NC, USA.
+*-------------------------------------------------------------*/
+
+%macro Chart_AutoRegression(returns,
+								   asset=,
+								   lag=,
+								   title= AutoRegression Analysis for &asset,
+								   ALL= FALSE, 
+								   ACF= TRUE, 
+								   PACF= TRUE, 
+								   WN= FALSE,
+								   IACF= FALSE,
+								   RESIDUAL= FALSE,
+								   SeasonalAdjusted= FALSE,
+								   SeasonalComponent= FALSE,
+								   SeasonalCycle= FALSE,
+								   TrendComponent= FALSE,
+								   TrendCycleComponent= FALSE,
+								   TrendCycleSeasonal= FALSE,
+								   dateColumn= Date);
+
+%local autoreg;
+/*Find all variable names excluding the date column and risk free variable*/
+%let autoreg= %get_number_column_names(_table= &returns, _exclude= &dateColumn); 
+%put AUTOREG IN return_calculate: (&autoreg);
+
+title "&title";
+ods graphics on;
+proc timeseries data= &returns 
+plots= (
+%if &All= TRUE %then %do;
+ALL
+%end;
+
+%else %do;
+	%if &ACF= TRUE %then %do;
+	ACF
+	%end;
+
+	%if &PACF= TRUE %then %do;
+	PACF
+	%end;
+
+	%if &WN= TRUE %then %do;
+	WN
+	%end;
+
+	%if &IACF= TRUE %then %do;
+	IACF
+	%end;
+
+	%if &Residual= TRUE %then %do;
+	RESIDUAL
+	%end;
+
+	%if &SeasonalAdjusted= TRUE %then %do;
+	SA
+	%end;
+
+	%if &SeasonalComponent= TRUE %then %do;
+	SC
+	%end;
+
+	%if &SeasonalCycle= TRUE %then %do;
+	CYCLES
+	%end;
+
+	%if &TrendComponent= TRUE %then %do;
+	TC
+	%end;
+
+	%if &TrendCycleComponent= TRUE %then %do;
+	TCC
+	%end;
+
+	%if &TrendCycleSeasonal= TRUE %then %do;
+	TCS
+	%end;
+%end;
+);
+var &asset ;
+corr/ nlag= &lag;
+run; 
+
+ods graphics off;
+
+proc datasets lib= work nolist kill;
+quit;
+
+%mend chart_autoregression;
+
+

--- a/Performance Analytics Library/macro/Chart_Correlation.sas
+++ b/Performance Analytics Library/macro/Chart_Correlation.sas
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------
+* NAME: Chart_Correlation.sas
+*
+* PURPOSE: Create a simple correlation plot matrix with options using a returns data set.
+*
+* MACRO OPTIONS:
+* returns - required.  Data Set containing returns.
+* title- required.  Title for histogram. [Default= asset name]
+* histogram - optional.  Option to insert histograms for each asset along the diagonal of the plot matrix.
+* histogramDensity - option.  Selects a type of density to overlay on histograms along the diagonal.  [Default= normal] {Normal, Kernel}
+* color- option to change the color of the scatter plot points [Default= carolina blue]
+* symbol- option to change the symbol of the scatter plot points [Default= circle] See list of possible symbols at SAS product documentation (markerattrs symbol)
+* size- option to change the size (in pixels) of the plot points [Default= 6]
+* ellipse- option to add a predictive ellipse to scatter plots [Default= FALSE] {True, False}
+* ellipseType- if ellipse is overlayed, specifies type [Default= predicted] {mean, predicted}
+* alpha- if ellipse is overlayed, specifies value of alpha for predictive bands [Default= 0.05]
+* dateColumn- specifies the date column for returns in the data set. [Default= Date]
+*
+* MODIFIED:
+* 1/14/2016 – CJ - Initial Creation
+*
+* Copyright (c) 2016 by The Financial Risk Group, Cary, NC, USA.
+*-------------------------------------------------------------*/
+
+%macro chart_correlation(returns, 
+							title= Portfolio Asset Correlations,
+							histogram= FALSE,
+							histogramDensity= normal,
+							color= cornflowerblue,
+							symbol= circle,
+							size= 6, 
+							ellipse= FALSE, 
+							ellipseType= predicted,
+							alpha= 0.05,
+							dateColumn= Date);
+
+%local vars;
+/*Find all variable names excluding the date column and risk free variable*/
+%let vars= %get_number_column_names(_table= &returns, _exclude= &dateColumn); 
+%put VARS IN return_calculate: (&vars);
+
+PROC SGSCATTER data = &returns;
+MATRIX &vars
+/
+%if &histogram= TRUE %then %do;
+diagonal = (histogram &histogramDensity)
+%end;
+ markerattrs = (color = &color)
+ markerattrs = (symbol = &symbol size= &size)
+ %if &ellipse= TRUE %then %do;
+ ellipse=(alpha= &alpha type= &ellipseType)
+ %end;
+ ;
+ title "&title";
+run;
+
+%mend chart_correlation;

--- a/Performance Analytics Library/macro/Chart_Regression.sas
+++ b/Performance Analytics Library/macro/Chart_Regression.sas
@@ -1,0 +1,68 @@
+/*---------------------------------------------------------------
+* NAME: Chart_Regression.sas
+*
+* PURPOSE: Create a simple regression chart with options using a returns data set.
+*
+* MACRO OPTIONS:
+* returns - required.  Data Set containing returns.
+* xvar- required.  Specifies the variable or asset to be plotted on the x-axis.
+* yvar- required.  Specifies the variable or asset to be plotted on the y-axis (a benchmark asset).
+* title- required.  Title for Scatter Plot. [Default= xvar versus yvar Regression Plot]
+* ExcessReturns- logical.  Option to plot returns in excess of the benchmark rather than returns. {TRUE, FALSE}
+* Rf- option.  If excessReturns is true, then specifies the risk free rate as a number or as a benchmark asset [Rf= 0.05, Rf= SPY].
+* grid- option.  Overlay a grid aligned with the points on the x and y axis.
+* transparency- option.  Specifies the level of transparency for data symbols.
+* color- option to change the color of the scatter plot points [Default= carolina blue]
+* symbol- option to change the symbol of the scatter plot points [Default= circle] See list of possible symbols at SAS product documentation (markerattrs symbol)
+* size- option to change the size (in pixels) of the plot points [Default= 6]
+* loess- option to overlay a loess fit to the scatter plot for comparison.  Logical, [Default= false].
+* cl- option.  If regLine= TRUE, option to create confidence limits for the regression line. {CLM, CLI}
+* degree- option.  If regLine= TRUE, specifies linear or quadratic fit.  For linear, degree=1, for quadratic, degree=2.
+* alpha- if ellipse is overlayed, specifies value of alpha for predictive bands [Default= 0.05]
+* dateColumn- specifies the date column for returns in the data set. [Default= Date]
+*
+* MODIFIED:
+* 1/22/2016 – CJ - Initial Creation
+*
+* Copyright (c) 2016 by The Financial Risk Group, Cary, NC, USA.
+*-------------------------------------------------------------*/
+
+%macro chart_regression(returns, 
+							xvar=, 
+							yvar=, 
+							title= &xvar versus &yvar Regression Plot,
+							ExcessReturns= FALSE,
+							Rf= 0,
+							grid= FALSE,
+							transparency= 0.35,
+							color= cornflowerblue,
+							size= 6,
+							symbol= circle,
+							loess= FALSE,
+							cl= CLI,
+							degree= 1,
+							alpha= 0.05,
+							dateColumn= Date);
+
+%if &ExcessReturns= TRUE %then %do;
+%return_excess(&returns, Rf= &Rf, dateColumn= &dateColumn, outReturn= &returns);
+%end;
+
+PROC SGSCATTER data = &returns;
+plot &yvar*&xvar
+/
+%if &loess= TRUE %then %do;
+loess=(alpha= &alpha degree=&degree &cl lineattrs= (pattern= mediumdash))
+%end;
+
+%if &grid= TRUE %then %do;
+grid
+%end;
+
+markerattrs=(color=&color size= &size symbol= &symbol)
+reg=(alpha= &alpha degree=&degree &cl)
+transparency= &transparency;
+ title "&title";
+run;
+
+%mend chart_regression;

--- a/Performance Analytics Library/macro/Chart_Scatter.sas
+++ b/Performance Analytics Library/macro/Chart_Scatter.sas
@@ -1,0 +1,67 @@
+/*---------------------------------------------------------------
+* NAME: Chart_Scatter.sas
+*
+* PURPOSE: Create a simple correlation plot matrix with options using a returns data set.
+*
+* MACRO OPTIONS:
+* returns - required.  Data Set containing returns.
+* xvar- required.  Specifies the variable or asset to be plotted on the x-axis.
+* yvar- required.  Specifies the variable or asset to be plotted on the y-axis.
+* title- required.  Title for Scatter Plot. [Default= xvar versus yvar Scatter]
+* grid- option.  Overlay a grid aligned with the points on the x and y axis.
+* transparency- option.  Specifies the level of transparency for data symbols.
+* color- option to change the color of the scatter plot points [Default= carolina blue]
+* symbol- option to change the symbol of the scatter plot points [Default= circle] See list of possible symbols at SAS product documentation (markerattrs symbol)
+* size- option to change the size (in pixels) of the plot points [Default= 6]
+* regLine- option to overlay a regression line on the scatter plot. {TRUE, FALSE}
+* cl- option.  If regLine= TRUE, option to create confidence limits for the regression line. {CLM, CLI}
+* degree- option.  If regLine= TRUE, specifies linear or quadratic fit.  For linear, degree=1, for quadratic, degree=2.
+* ellipse- option to add a predictive ellipse to scatter plots [Default= FALSE] {True, False}
+* ellipseType- if ellipse is overlayed, specifies type [Default= predicted] {mean, predicted}
+* alpha- if ellipse is overlayed, specifies value of alpha for predictive bands [Default= 0.05]
+* dateColumn- specifies the date column for returns in the data set. [Default= Date]
+*
+* MODIFIED:
+* 1/20/2016 – CJ - Initial Creation
+*
+* Copyright (c) 2016 by The Financial Risk Group, Cary, NC, USA.
+*-------------------------------------------------------------*/
+
+%macro chart_scatter(returns, 
+							xvar=, 
+							yvar=, 
+							title= &xvar versus &yvar Scatter,
+							grid= FALSE,
+							transparency= 0.35,
+							color= cornflowerblue,
+							size= 6,
+							symbol= circle,
+							regLine= FALSE,
+							cl= CLI,
+							degree= 1,
+							alpha= 0.05,
+							ellipse= FALSE,
+							EllipseType= predicted,
+							dateColumn= Date);
+
+
+PROC SGSCATTER data = &returns;
+plot &yvar*&xvar
+/reg
+%if &grid= TRUE %then %do;
+grid
+%end;
+  markerattrs=(color=&color size= &size symbol= &symbol)
+%if &regline= TRUE %then %do;
+  reg=(alpha= &alpha &cl degree=&degree)
+%end;
+   transparency= &transparency
+
+%if &ellipse= TRUE %then %do;
+    ellipse=(alpha= &alpha type=&EllipseType)
+%end;
+;
+ title "&title";
+run;
+
+%mend chart_scatter;

--- a/Performance Analytics Library/macro/Chart_histogram.sas
+++ b/Performance Analytics Library/macro/Chart_histogram.sas
@@ -1,51 +1,109 @@
 /*---------------------------------------------------------------
-* NAME: CAPM_JensenAlpha.sas
+* NAME: Chart_Histogram.sas
 *
-* PURPOSE: Create a simple histogram for an asset or instrument using returns data set.
+* PURPOSE: Create a simple histogram with options for an asset or instrument using a returns data set.
 *
 * MACRO OPTIONS:
 * returns - required.  Data Set containing returns.
 * asset- required.  Specifies the benchmark asset or index in the returns data set.
-* type- specifies whether y-axis should go by probability or frequency. {count, percent}, [Default= count]  
+* scale- specifies whether the y-axis should go by probability or frequency. {count, percent, proportion}, [Default= count]  
 * title- required.  Title for histogram. [Default= asset name]
-* xlabel- required.  Label for the x-axis.  [Default= "Returns"]
-* ylabel- required.  Label for the y-axis.  [Default= "Frequency"]
+* bindwidth- specifies the range of returns to select for each bar. [Default= 0.001]
 * density- option to overlay a normal density curve on top of the histogram for comparison. If true, [Density= Density]
+* color- option to change the color of the histogram bins [Default= carolina blue]
+* density color- option to change the color of the density line [Default= red]
+* histogramTransparency- option to change the transparency of the histogram bins [Default= 0.8]
+* keepOutliers- option to delete outlier returns from the histogram within the range of Q1- 1.5IQR and Q3+1.5IQR [Default= false]
+* qqplot- option to display a QQ Plot in addition to the histogram [Default= false]
+* rug- option to display a fringe plot overlayed onto the histogram [Default= false]
+* dateColumn- specifies the date column for returns in the data set. [Default= Date]
+*
+* Future Modifications: Overlay VaR line once the VaR macro is completed.
 *
 * MODIFIED:
-* 7/24/2015 – CJ - Initial Creation
+* 1/7/2016 – CJ - Initial Creation
 *
-* Copyright (c) 2015 by The Financial Risk Group, Cary, NC, USA.
+* Copyright (c) 2016 by The Financial Risk Group, Cary, NC, USA.
 *-------------------------------------------------------------*/
 
 %macro Chart_histogram(returns, 
 								asset=,
-								type= count,
-								title= &asset,
-								xlabel= Returns,
-								ylabel= Frequency,
-								density=0,
+								scale= count,
+								title= &asset returns,
+								binwidth= 0.001,
+								density=TRUE,
+								color= cornflowerblue,
+								densitycolor= red,
+								histogramTransparency= 0.8, 
+								KeepOutliers= TRUE,
+								qqplot= FALSE,
+								rug= FALSE,
 								dateColumn= Date);
 
-%local lib ds;
-/***********************************
-*Figure out 2 level ds name of RETURNS
-************************************/
-%let lib = %scan(&returns,1,%str(.));
-%let ds = %scan(&returns,2,%str(.));
-%if "&ds" = "" %then %do;
-%let ds=&lib;
-%let lib=work;
-%end;
-%put lib:&lib ds:&ds;
+%let IQR= %ranname();
 
-proc sgplot data= &returns;
-histogram &asset/ scale= &type  binwidth= 0.001;
-title "&title";
-Xaxis label= "&xlabel";
-Yaxis label= "&ylabel" ;
-%if %upcase(&density)= %upcase(density) %then %do;
-&density &asset;
-%end;
+%if &KeepOutliers= FALSE %then %do;
+proc univariate data= &returns noprint;
+var &asset;
+output out=&IQR QRange= InterQuartileRange Q1= Quartile1 Q3= Quartile3;
 run;
+
+data &IQR;
+set &IQR;
+call symput('InterQuartileRange', InterQuartileRange);
+call symput('Quartile1', Quartile1);
+call symput('Quartile3', Quartile3);
+run;
+
+%let InterQR= %sysfunc(putn(&InterQuartileRange, best12.2));
+%let Quartile1= %sysfunc(putn(&Quartile1, best12.2));
+%let Quartile3= %sysfunc(putn(&Quartile3, best12.2));
+%let lowerBound= %sysevalf(&Quartile1 - 1.5*&InterQR);
+%let upperBound= %sysevalf(&Quartile3 + 1.5*&InterQR);
+
+data &returns;
+format &asset percent10.2;
+set &returns;
+where &asset > &lowerBound and &asset < &upperBound;
+run;
+%end;
+
+proc template;
+define statgraph fringeplot;
+dynamic VAR VARLABEL;
+begingraph;
+entrytitle "Histogram for &asset";
+layout overlay / xaxisopts= (label= VARLABEL)
+				 yaxisopts= (offsetmin= 0.03);
+%if %upcase(&rug)= %upcase(true) %then %do;
+		fringeplot VAR/ datatransparency= &histogramTransparency fringeheight= 3pct;
+%end;
+		histogram &asset / datatransparency= &histogramTransparency scale=&scale binwidth= &binwidth fillattrs= (color= &color);
+		%if %upcase(&density)= %upcase(true) %then %do;
+			densityplot &asset / lineattrs=(color=&densitycolor) normal() name="Normal";
+			densityplot &asset / lineattrs=(color=darkblue) kernel() name="Kernel";
+				discretelegend "Normal" "Kernel" / location=inside across=1
+					autoalign=(topright topleft);
+		%end;
+	endlayout;
+	endgraph;
+end;
+run;
+title "&title";
+proc sgrender data= &returns template= fringeplot;
+dynamic var= "&asset" varlabel= "&asset returns"; 
+run;
+
+%if &qqplot= TRUE %then %do;
+proc univariate data= &returns noprint;
+var &asset;
+qqplot;
+title "QQ Plot for &asset";
+run;
+%end;
+
+proc datasets lib= work nolist;
+delete &IQR;
+quit;
 %mend;
+ 


### PR DESCRIPTION
Not sure exactly how to test these, but implemented as many equivalent options and anything else I thought might be helpful for charting.  

chart_autoregression is the equivalent of chart.acfPlus, but with all the additional features of proc timeseries, I decided to implement as many other charts as available. acfPlus seemed a bit weak anyway.  If the difference in name is confusing I'll change that for the next pull.